### PR TITLE
Upgrade dappkit, sdk deps to fix expo go on ios

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,9 +8,9 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "@celo/connect": "^1.0.1",
-    "@celo/contractkit": "^1.0.0",
-    "@celo/dappkit": "^1.0.0",
+    "@celo/connect": "^1.1.0",
+    "@celo/contractkit": "^1.1.0",
+    "@celo/dappkit": "^1.1.0",
     "crypto-browserify": "^3.12.0",
     "expo": "^40.0.1",
     "expo-file-system": "^10.0.0",


### PR DESCRIPTION
# Description
This should now make it possible to run this on iOS with the Expo Go App. It's possible that the Expo `Linking` dependency removal in dappkit `1.1.0` did it but honestly I'm not positive.

# Testing
Works on my XR as well as on an iOS emulator (iPhone 12).

Closes celo-org/celo-monorepo#7481
